### PR TITLE
Migrating from React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "peerDependencies": {
     "pdfjs-dist": "^1.6.380",
+    "prop-types": "^15.5.10",
     "react": "^15.4.1",
     "react-dom": "^15.4.1"
   }

--- a/src/PDF.js
+++ b/src/PDF.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 function buildPages(file) {
   let arr = [];
@@ -19,13 +20,13 @@ export default class PDF extends Component {
   total = 100;
 
   static propTypes = {
-    onProgress: React.PropTypes.func,
-    onComplete: React.PropTypes.func,
-    onError: React.PropTypes.func,
-    url: React.PropTypes.string.isRequired,
-    headers: React.PropTypes.object,
-    style: React.PropTypes.object,
-    className: React.PropTypes.string
+    onProgress: PropTypes.func,
+    onComplete: PropTypes.func,
+    onError: PropTypes.func,
+    url: PropTypes.string.isRequired,
+    headers: PropTypes.object,
+    style: PropTypes.object,
+    className: PropTypes.string
   };
 
   onProgress(progressData) {

--- a/src/Page.js
+++ b/src/Page.js
@@ -1,12 +1,13 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
 
 export default class Page extends Component {
   static propTypes = {
-    page: React.PropTypes.shape({
-      key: React.PropTypes.number.isRequired,
-      file: React.PropTypes.shape({
-        getPage: React.PropTypes.func.isRequired
+    page: PropTypes.shape({
+      key: PropTypes.number.isRequired,
+      file: PropTypes.shape({
+        getPage: PropTypes.func.isRequired
       })
     }).isRequired
   };


### PR DESCRIPTION
Migrating from React.PropTypes to remove deprication warnings React 15.5.0

[https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes)